### PR TITLE
Fixed null value handling for certain (corrupt) data streams

### DIFF
--- a/EODHistoricalData.NET.Tests/Consts.cs
+++ b/EODHistoricalData.NET.Tests/Consts.cs
@@ -8,6 +8,7 @@ namespace EODHistoricalData.NET.Tests
     {
         internal const string ApiToken = "OeAFFmMliFG5orCUuwAKQ8l4WWFQ67YX";
         internal const string TestSymbol = "AAPL.US";
+        internal const string TestSymbolNullData = "AEDAUD.FOREX";
         internal const string TestIndex = "FCHI.INDX";
         internal const string TestETF = "VTI.US";
         internal const string TestFund = "SWPPX.US";

--- a/EODHistoricalData.NET.Tests/Consts.cs
+++ b/EODHistoricalData.NET.Tests/Consts.cs
@@ -9,6 +9,7 @@ namespace EODHistoricalData.NET.Tests
         internal const string ApiToken = "OeAFFmMliFG5orCUuwAKQ8l4WWFQ67YX";
         internal const string TestSymbol = "AAPL.US";
         internal const string TestSymbolNullData = "AEDAUD.FOREX";
+        internal const string TestSymbolReturnsEmpty = "VRGWX.NMFQS";
         internal const string TestIndex = "FCHI.INDX";
         internal const string TestETF = "VTI.US";
         internal const string TestFund = "SWPPX.US";

--- a/EODHistoricalData.NET.Tests/StockPriceDataTests.cs
+++ b/EODHistoricalData.NET.Tests/StockPriceDataTests.cs
@@ -61,6 +61,13 @@ namespace EODHistoricalData.NET.Tests
             Assert.IsTrue(prices.Count > 0);
         }
 
+        [TestMethod]
+        public void historical_valid_symbols_returns_empty()
+        {
+            EODHistoricalDataClient client = new EODHistoricalDataClient(Consts.ApiToken, true);
+            List<HistoricalPrice> prices = client.GetHistoricalPrices(Consts.TestSymbolReturnsEmpty, null, null);
+            Assert.IsTrue(prices.Count == 0);
+        }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]

--- a/EODHistoricalData.NET.Tests/StockPriceDataTests.cs
+++ b/EODHistoricalData.NET.Tests/StockPriceDataTests.cs
@@ -54,6 +54,15 @@ namespace EODHistoricalData.NET.Tests
         }
 
         [TestMethod]
+        public void historical_valid_symbols_null_data_returns_prices()
+        {
+            EODHistoricalDataClient client = new EODHistoricalDataClient(Consts.ApiToken, true);
+            List<HistoricalPrice> prices = client.GetHistoricalPrices(Consts.TestSymbolNullData, null, null);
+            Assert.IsTrue(prices.Count > 0);
+        }
+
+
+        [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void realtime_null_list_throws_exception()
         {

--- a/EODHistoricalData.NET/BusinessObjects/HistoricalPrice.cs
+++ b/EODHistoricalData.NET/BusinessObjects/HistoricalPrice.cs
@@ -59,7 +59,8 @@ namespace EODHistoricalData.NET
             DateParseHandling = DateParseHandling.None,
             Converters =
             {
-                new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal }
+                new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal },
+                new NullConverter()
             },
         };
     }

--- a/EODHistoricalData.NET/NullConverter.cs
+++ b/EODHistoricalData.NET/NullConverter.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EODHistoricalData.NET
+{
+    public class NullConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return (objectType == typeof(System.Double)) || (objectType == typeof(System.Int64));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (objectType == typeof(System.Double))
+            {
+                if (reader.TokenType == JsonToken.Float) return reader.Value;
+                if (reader.TokenType == JsonToken.Integer) return Convert.ToDouble(reader.Value);
+                if (reader.TokenType == JsonToken.Null) return Double.NaN;
+            }
+
+            if (objectType == typeof(System.Int64))
+            {
+                if (reader.TokenType == JsonToken.Integer) return Convert.ToInt64(reader.Value);
+                if (reader.TokenType == JsonToken.Null) return (long)0;
+            }
+
+            return null;
+        }
+
+        public override bool CanWrite { get { return false; } }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/EODHistoricalData.NET/StockPriceDataClient.cs
+++ b/EODHistoricalData.NET/StockPriceDataClient.cs
@@ -21,7 +21,7 @@ namespace EODHistoricalData.NET
 
         List<HistoricalPrice> GetHistoricalPricesFromResponse(HttpResponseMessage response)
         {
-            return HistoricalPrice.GetListFromJson(response.Content.ReadAsStringAsync().Result);
+            return HistoricalPrice.GetListFromJson(response.Content.ReadAsStringAsync().Result) ?? new List<HistoricalPrice>();
         }
 
         internal List<RealTimePrice> GetRealTimePrices(string[] symbols)


### PR DESCRIPTION
There are two fixes included in this pull request:

1, There are certain instruments that return (null) open/close/low/high values instead of floats in the json files (you can test it with _AEDAUD.FOREX_, for example. This threw an exception before, but now only the datalines for those with (null) values are ignored.

2, There are other instruments that return empty json files when requested, like _VRGWX.NMFQS_. These also threw an exception, now they return an empty list of HistoricalPrice.

I included the two new unit tests as well.

You will need at least a basic subscription to test these cases. (And you need to replace the ApiToken in the Consts.cs with your API key.)