### PR TITLE
Change target framework to .NET Standard

### DIFF
--- a/EODHistoricalData.NET/EODHistoricalData.NET.csproj
+++ b/EODHistoricalData.NET/EODHistoricalData.NET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
See issue https://github.com/EodHistoricalData/EODHistoricalData.NET/issues/5

### Use case

I want to reference EODHistoricalData.NET from another class library, that targets .NET Standard project.
Currently that is not possible since EODHistoricalData.NET is targetting .NET Core.

See this thread
https://stackoverflow.com/questions/46087573/convert-net-core-2-0-class-libraries-to-net-standard

Retargetting EODHistoricalData.NET from .NET Core to .NET Standard would make it referencable from both .NET Framework and .NET Core apps.

The solution is to change a section in the .csproj file like this

from
```
 <PropertyGroup>
    <TargetFramework>netcoreapp2.0</TargetFramework>
  </PropertyGroup>
```
to
```
<PropertyGroup>
    <TargetFramework>netstandard2.0</TargetFramework>
  </PropertyGroup>
```