### PR TITLE
Handle non-parsing json returned for stock price query. The data valu…

### DIFF
--- a/EODHistoricalData.NET.Tests/Consts.cs
+++ b/EODHistoricalData.NET.Tests/Consts.cs
@@ -8,6 +8,7 @@ namespace EODHistoricalData.NET.Tests
     {
         internal const string ApiToken = "OeAFFmMliFG5orCUuwAKQ8l4WWFQ67YX";
         internal const string TestSymbol = "AAPL.US";
+        internal const string TestSymbolNonParsingData = "ALF.US";
         internal const string TestSymbolNullData = "AEDAUD.FOREX";
         internal const string TestSymbolReturnsEmpty = "VRGWX.NMFQS";
         internal const string TestIndex = "FCHI.INDX";

--- a/EODHistoricalData.NET.Tests/StockPriceDataTests.cs
+++ b/EODHistoricalData.NET.Tests/StockPriceDataTests.cs
@@ -117,5 +117,14 @@ namespace EODHistoricalData.NET.Tests
             RealTimePrice price = client.GetRealTimePrice(Consts.TestSymbol);
             Assert.IsNotNull(price);
         }
+
+        [TestMethod]
+        public void realtime_valid_symbol_return_nonparsing_result()
+        {
+            EODHistoricalDataClient client = new EODHistoricalDataClient(Consts.ApiToken, true);
+            RealTimePrice price = client.GetRealTimePrice(Consts.TestSymbolNonParsingData);
+            Assert.IsNotNull(price);
+            Assert.IsTrue(price.ErrorMessages.Count > 1);
+        }
     }
 }

--- a/EODHistoricalData.NET/BusinessObjects/RealTimePrice.cs
+++ b/EODHistoricalData.NET/BusinessObjects/RealTimePrice.cs
@@ -52,6 +52,9 @@ namespace EODHistoricalData.NET
 
         [JsonIgnore]
         public DateTime TimestampAsDateTime { get; set; }
+
+        [JsonIgnore]
+        public List<string> ErrorMessages { get; set; }
     }
 
     public partial class RealTimePrice
@@ -59,6 +62,7 @@ namespace EODHistoricalData.NET
         public static RealTimePrice FromJson(string json)
         {
             RealTimePrice result = JsonConvert.DeserializeObject<RealTimePrice>(json, EODHistoricalData.NET.ConverterRealTimePrice.Settings);
+            result.ErrorMessages = ConverterRealTimePrice.Errors;
             result.TimestampAsDateTime = DateTimeOffset.FromUnixTimeSeconds(result.Timestamp).DateTime;
             return result;
         }
@@ -78,6 +82,7 @@ namespace EODHistoricalData.NET
 
     internal static class ConverterRealTimePrice
     {
+        public static List<string> Errors = new List<string>();
         public static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
         {
             MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
@@ -85,6 +90,11 @@ namespace EODHistoricalData.NET
             Converters =
             {
                 new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal }
+            },
+            Error = delegate (object sender, Newtonsoft.Json.Serialization.ErrorEventArgs args)
+            {
+                Errors.Add(args.ErrorContext.Error.Message);
+                args.ErrorContext.Handled = true;
             },
         };
     }


### PR DESCRIPTION
…es contain "NA" which is not iso format.

I had to add some basic handling of problematic json on price requests. It seems that the api sometimes returns content that looks like this:

{"code":"ALF.US","timestamp":"NA","gmtoffset":"NA","open":"NA","high":"NA","low":"NA","close":"NA","volume":"NA","previousClose":"NA","change":"NA","change_p":"NA"}

which causes and exception in parsing. Not sure if you would prefer to solve the api response or turn the price check into a null, but the exception is annoying?