### PR TITLE
Added ISIN to exchanges endpoint

### DIFF
--- a/EODHistoricalData.NET/BusinessObjects/Instrument.cs
+++ b/EODHistoricalData.NET/BusinessObjects/Instrument.cs
@@ -34,9 +34,11 @@ namespace EODHistoricalData.NET
 
         [JsonProperty("Type")]
         public string Type { get; set; }
+        
+        [JsonProperty("Isin")]
+        public string Isin { get; set; }
     }
-
-
+    
     public partial class Instrument
     {
         public static List<Instrument> FromJson(string json) => JsonConvert.DeserializeObject<List<Instrument>>(json, EODHistoricalData.NET.ConverterInstrument.Settings);


### PR DESCRIPTION
For the endpoint:-

https://eodhistoricaldata.com/api/exchanges/us?api_token={token}&fmt=json

There is a field for Isin (not in capitals)

    {
        "Code": "A",
        "Name": "Agilent Technologies Inc",
        "Country": "USA",
        "Exchange": "NYSE",
        "Currency": "USD",
        "Type": "Common Stock",
        "Isin": "US00846U1016"
    },
    {
        "Code": "AA",
        "Name": "Alcoa Corporation",
        "Country": "USA",
        "Exchange": "NYSE",
        "Currency": "USD",
        "Type": "Common Stock",
        "Isin": "US0138721065"
    },

I've added this property.
