### PR TITLE
Update retry logic and raise custom exception to the caller 

### DIFF
--- a/EODHistoricalData.NET/BusinessObjects/Exceptions.cs
+++ b/EODHistoricalData.NET/BusinessObjects/Exceptions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Net;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+
+namespace EODHistoricalData.NET.BusinessObjects
+{
+    [Serializable]
+    public class EODException : ApplicationException
+    {
+        public HttpStatusCode Status { get; private set; }
+        public string Details { get; private set; }
+        public EODException(HttpStatusCode status, string message, string details)
+            : this(message, null)
+        {
+            this.Details = details;
+            this.Status = status;
+        }
+
+        public EODException() : this("Something has gone wrong.", null) { }
+        public EODException(string message, Exception inner = null) : base(message, inner) { }
+
+        protected EODException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            this.Details = info.GetString("Details");
+            this.Status = (HttpStatusCode)info.GetValue("Status", typeof(HttpStatusCode));
+        }
+
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+            info.AddValue("Details", this.Details);
+            info.AddValue("Status", this.Status);
+            base.GetObjectData(info, context);
+        }
+    }
+}

--- a/EODHistoricalData.NET/HttpApiClient.cs
+++ b/EODHistoricalData.NET/HttpApiClient.cs
@@ -29,32 +29,30 @@ namespace EODHistoricalData.NET
 
         protected T ExecuteQuery<T>(string uri, QueryHandler<T> handler)
         {
-            Polly.Retry.RetryPolicy<HttpResponseMessage> httpRetryPolicy = Policy
-                .HandleResult<HttpResponseMessage>(r => r.StatusCode == (HttpStatusCode)429)
-                .WaitAndRetry(new[]
-                {
-                    TimeSpan.FromSeconds(30),
-                    TimeSpan.FromSeconds(60),
-                    TimeSpan.FromSeconds(90)
-                },
-                onRetry: (outcome, timespan, retryAttempt, context) =>
-                {
-                    //included for debug to see what the response is
-                });
+            var retryPolicy = Policy
+                .HandleResult<HttpResponseMessage>(response => Utils.CheckStatus(response.StatusCode))
+                .Or<HttpRequestException>()
+                .WaitAndRetryAsync(retryCount: Utils.MAX_HTTP_RETRIES,
+                                   sleepDurationProvider: Utils.CalculateRetryInterval,
+                                   onRetry: (exception, sleepDuration, attemptNumber, context) =>
+                                   {
+                                       //Console.WriteLine($"Too many requests. Retrying in {sleepDuration}. {attemptNumber} / {Utils.MAX_HTTP_RETRIES}");
+                                   });
 
-            var response = httpRetryPolicy.ExecuteAndCapture(() => _httpClient.GetAsync(uri).Result);
+            var response = retryPolicy.ExecuteAndCaptureAsync(() => _httpClient.GetAsync(uri)).Result;
 
             if (response.Outcome == OutcomeType.Successful)
             {
                 if (response.Result.IsSuccessStatusCode)
                     return handler(response.Result);
 
-                throw new HttpRequestException($"There was an error while executing the HTTP query. Reason: {response.Result.ReasonPhrase}");
+                throw new HttpRequestException($"There was an error while executing the HTTP query.",
+                    new BusinessObjects.EODException(response.Result.StatusCode, response.Result.ReasonPhrase, response.Result.ToString()));
             }
             else
             {
                 var reason = response.FinalHandledResult != null ? response.FinalHandledResult.ReasonPhrase : response.FinalException.Message;
-                throw new HttpRequestException($"There was an error while executing the HTTP query. Reason: {reason}");
+                throw new HttpRequestException($"The HTTP query failed. Reason: {reason}");
             }
         }
 

--- a/EODHistoricalData.NET/Utils.cs
+++ b/EODHistoricalData.NET/Utils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Text;
 
 namespace EODHistoricalData.NET
@@ -25,6 +26,20 @@ namespace EODHistoricalData.NET
             }
 
             return sb.ToString();
+        }
+
+        internal static int MAX_HTTP_RETRIES = 3;
+
+        internal static bool CheckStatus(HttpStatusCode status)
+        {
+            return status == (HttpStatusCode)429;
+        }
+
+        internal static TimeSpan CalculateRetryInterval(int attempt)
+        {
+            //try to make this the second half of the minute
+            //as this is likely to fail in the first part of the minute
+            return TimeSpan.FromSeconds(attempt * 30 + (30 * (attempt - 1)));
         }
     }
 }


### PR DESCRIPTION
Hi there, I am continuing to have 429 errors from the server although these changes have helped mitigate it.

I would welcome some dialog as to what can be done to avoid this because I do believe that I am below the rate limit although I do not always receive the headers indicating my rate usage vs limit. I have tried discussing with support but I think a more technical review is needed.