### PR TITLE
Batch methods added and 429 retry updates

### DIFF
--- a/EODHistoricalData.NET.Tests/Consts.cs
+++ b/EODHistoricalData.NET.Tests/Consts.cs
@@ -26,5 +26,8 @@ namespace EODHistoricalData.NET.Tests
         internal static DateTime OptionsTradeEndDate = new DateTime(2019, 7, 1);
         internal static string[] MultipleTestSymbol = new[] { TestSymbol, "VTI", "EUR.FOREX" };
         internal static string[] MultipleSymbolEarnings = new[] { "SNPS.US", "MDI.TO" };
+        internal static DateTime CurrentDate = DateTime.UtcNow.Date;
+        internal static DateTime YesterdaysDate = DateTime.UtcNow.AddDays(-1).Date;
+        internal static string[] MultipleSymbolsBulkEOD = new[] { "AAPL", "TSLA" };
     }
 }

--- a/EODHistoricalData.NET.Tests/StockPriceDataAsyncTests.cs
+++ b/EODHistoricalData.NET.Tests/StockPriceDataAsyncTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -47,6 +48,21 @@ namespace EODHistoricalData.NET.Tests
         {
             using var  client = new EODHistoricalDataAsyncClient(Consts.ApiToken, true);
             var prices = await client.GetHistoricalPricesAsync(Consts.TestSymbol, Consts.StartDate, Consts.EndDate);
+            var minDate = prices.Min(x => x.Date).Date;
+            var maxDate = prices.Max(x => x.Date).Date;
+            Assert.IsTrue(minDate == Consts.StartDate);
+            Assert.IsTrue(maxDate == Consts.EndDate);
+        }
+
+        [TestMethod]
+        public async Task historical_valid_symbols_1000_requests_with_from_and_to_date_returns_prices_async()
+        {
+            using var client = new EODHistoricalDataAsyncClient(Consts.ApiToken, true);
+            List<HistoricalPrice> prices = null;
+            for (int i = 0; i < 2000; i++)
+            {
+                prices = await client.GetHistoricalPricesAsync(Consts.TestSymbol, Consts.StartDate, Consts.EndDate);
+            }
             var minDate = prices.Min(x => x.Date).Date;
             var maxDate = prices.Max(x => x.Date).Date;
             Assert.IsTrue(minDate == Consts.StartDate);
@@ -118,6 +134,31 @@ namespace EODHistoricalData.NET.Tests
             using var  client = new EODHistoricalDataAsyncClient(Consts.ApiToken, true);
             var price = await client.GetRealTimePriceAsync(Consts.TestSymbol);
             Assert.IsNotNull(price);
+        }
+
+        [TestMethod]
+        public async Task last_day_price_symbol_result_async()
+        {
+            using var client = new EODHistoricalDataAsyncClient(Consts.ApiToken, true);
+            var prices = await client.GetBulkEndOfLastDayStocksAsync(Consts.YesterdaysDate, Consts.MultipleSymbolsBulkEOD); 
+            Assert.IsNotNull(prices);
+            Assert.IsTrue(prices.Count() == Consts.MultipleSymbolsBulkEOD.Length);
+        }
+
+        [TestMethod]
+        public async Task last_day_dividend_symbol_result_async()
+        {
+            using var client = new EODHistoricalDataAsyncClient(Consts.ApiToken, true);
+            var dividends = await client.GetBulkEndOfLastDayDividendsAsync(Consts.YesterdaysDate);
+            Assert.IsNotNull(dividends);
+        }
+
+        [TestMethod]
+        public async Task last_day_splits_symbol_result_async()
+        {
+            using var client = new EODHistoricalDataAsyncClient(Consts.ApiToken, true);
+            var splits = await client.GetBulkEndOfLastDaySplitsAsync(Consts.YesterdaysDate);
+            Assert.IsNotNull(splits);
         }
     }
 }

--- a/EODHistoricalData.NET/BusinessObjects/BulkFundamentalStocks.cs
+++ b/EODHistoricalData.NET/BusinessObjects/BulkFundamentalStocks.cs
@@ -8,12 +8,8 @@
 
 namespace EODHistoricalData.NET
 {
-    using EODHistoricalData.NET.BusinessObjects;
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
-    using System;
     using System.Collections.Generic;
-    using System.Globalization;
 
     public partial class BulkFundamentalStocks : Dictionary<int, FundamentalStock>
     {

--- a/EODHistoricalData.NET/BusinessObjects/Dividend.cs
+++ b/EODHistoricalData.NET/BusinessObjects/Dividend.cs
@@ -15,6 +15,15 @@ namespace EODHistoricalData.NET
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
 
+    public partial class BulkDividend : Dividend
+    {
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        [JsonProperty("dividend")]
+        public new string Value { get; set; }
+    }
+
     public partial class Dividend
     {
         [JsonProperty("date")]
@@ -45,6 +54,11 @@ namespace EODHistoricalData.NET
     public partial class Dividend
     {
         public static List<Dividend> FromJson(string json) => JsonConvert.DeserializeObject<List<Dividend>>(json, EODHistoricalData.NET.ConverterDividend.Settings);
+    }
+
+    public partial class BulkDividend
+    {
+        public static new List<BulkDividend> FromJson(string json) => JsonConvert.DeserializeObject<List<BulkDividend>>(json, EODHistoricalData.NET.ConverterDividend.Settings);
     }
 
     public static class SerializeDividend

--- a/EODHistoricalData.NET/BusinessObjects/Exceptions.cs
+++ b/EODHistoricalData.NET/BusinessObjects/Exceptions.cs
@@ -1,0 +1,39 @@
+﻿namespace EODHistoricalData.NET.BusinessObjects
+{
+    using System;
+    using System.Net;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    public class EODException : ApplicationException
+    {
+        public HttpStatusCode Status { get; private set; }
+        public string Details { get; private set; }
+        public EODException(HttpStatusCode status, string message, string details)
+            : this(message, null)
+        {
+            this.Details = details;
+            this.Status = status;
+        }
+
+        public EODException() : this("Something has gone wrong.", null) { }
+        public EODException(string message, Exception inner = null) : base(message, inner) { }
+
+        protected EODException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            this.Details = info.GetString("Details");
+            this.Status = (HttpStatusCode)info.GetValue("Status", typeof(HttpStatusCode));
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+            info.AddValue("Details", this.Details);
+            info.AddValue("Status", this.Status);
+            base.GetObjectData(info, context);
+        }
+    }
+}

--- a/EODHistoricalData.NET/BusinessObjects/HistoricalPrice.cs
+++ b/EODHistoricalData.NET/BusinessObjects/HistoricalPrice.cs
@@ -14,6 +14,15 @@ namespace EODHistoricalData.NET
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
 
+    public partial class BulkHistoricalPrice : HistoricalPrice
+    {
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        [JsonProperty("exchange_short_name")]
+        public string ExchangeShortName { get; set; }
+    }
+
     public partial class HistoricalPrice
     {
         [JsonProperty("date")]
@@ -36,6 +45,19 @@ namespace EODHistoricalData.NET
 
         [JsonProperty("volume")]
         public long Volume { get; set; }
+
+        [JsonProperty("change")]
+        public double Change { get; set; }
+
+        [JsonProperty("change_p")]
+        public double ChangePercentage { get; set; }
+    }
+
+    public partial class BulkHistoricalPrice
+    {
+        public static new BulkHistoricalPrice FromJson(string json) => JsonConvert.DeserializeObject<BulkHistoricalPrice>(json, EODHistoricalData.NET.ConverterHistoricalPrice.Settings);
+
+        public static new List<BulkHistoricalPrice> GetListFromJson(string json) => JsonConvert.DeserializeObject<List<BulkHistoricalPrice>>(json, EODHistoricalData.NET.ConverterHistoricalPrice.Settings);
     }
 
     public partial class HistoricalPrice
@@ -43,7 +65,6 @@ namespace EODHistoricalData.NET
         public static HistoricalPrice FromJson(string json) => JsonConvert.DeserializeObject<HistoricalPrice>(json, EODHistoricalData.NET.ConverterHistoricalPrice.Settings);
 
         public static List<HistoricalPrice> GetListFromJson(string json) => JsonConvert.DeserializeObject<List<HistoricalPrice>>(json, EODHistoricalData.NET.ConverterHistoricalPrice.Settings);
-
     }
 
     public static class SerializeHistoricalPrice

--- a/EODHistoricalData.NET/BusinessObjects/ShareSplit.cs
+++ b/EODHistoricalData.NET/BusinessObjects/ShareSplit.cs
@@ -15,6 +15,12 @@ namespace EODHistoricalData.NET
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
 
+    public partial class BulkShareSplit : ShareSplit
+    {
+        [JsonProperty("code")]
+        public string Code { get; set; }
+    }
+
     public partial class ShareSplit
     {
         [JsonProperty("date")]
@@ -45,9 +51,29 @@ namespace EODHistoricalData.NET
         }
     }
 
+    public partial class BulkShareSplit
+    {
+        public static new List<BulkShareSplit> FromJson(string json)
+        {
+            List<BulkShareSplit> splits = JsonConvert.DeserializeObject<List<BulkShareSplit>>(json, EODHistoricalData.NET.ConverterShareSplit.Settings);
+            foreach (BulkShareSplit split in splits)
+            {
+                string[] factors = split.Split.Split('/');
+                split.SplitFactor = decimal.Parse(factors[0], CultureInfo.InvariantCulture);
+                split.BaseNumber = decimal.Parse(factors[1], CultureInfo.InvariantCulture);
+            }
+            return splits;
+        }
+    }
+
     public static class SerializeShareSplit
     {
         public static string ToJson(this List<ShareSplit> self) => JsonConvert.SerializeObject(self, EODHistoricalData.NET.ConverterShareSplit.Settings);
+    }
+
+    public static class SerializeBulkShareSplit
+    {
+        public static string ToJson(this List<BulkShareSplit> self) => JsonConvert.SerializeObject(self, EODHistoricalData.NET.ConverterShareSplit.Settings);
     }
 
     internal static class ConverterShareSplit

--- a/EODHistoricalData.NET/EODHistoricalData.NET.csproj
+++ b/EODHistoricalData.NET/EODHistoricalData.NET.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/EODHistoricalData.NET/EODHistoricalDataAsyncClient.cs
+++ b/EODHistoricalData.NET/EODHistoricalDataAsyncClient.cs
@@ -7,8 +7,6 @@ namespace EODHistoricalData.NET
 {
     public class EODHistoricalDataAsyncClient : AuthentifiedClient, IDisposable
     {
-        public const string DateFormat = "yyyy-MM-dd";
-
         public EODHistoricalDataAsyncClient(string api, bool useProxy = false) : base(api)
         {
             _useProxy = useProxy;
@@ -85,7 +83,6 @@ namespace EODHistoricalData.NET
             return _splitDividendAsyncClient.GetShareSplitsAsync(symbol, startDate, endDate);
         }
 
-
         public Task<Options> GetOptionsAsync(string symbol, DateTime? startDate, DateTime? endDate, DateTime? startTradeDate = null, DateTime? endTradeDate = null)
         {
             if (symbol == null)
@@ -104,7 +101,7 @@ namespace EODHistoricalData.NET
 
             return _calendarDataAsyncClient.GetEarningsAsync(startDate, endDate, symbols);
         }
-        
+
         public Task<Ipos> GetIposAsync(DateTime? startDate = null, DateTime? endDate = null, string[] symbols = null)
         {
             if (_calendarDataAsyncClient == null)
@@ -126,7 +123,7 @@ namespace EODHistoricalData.NET
             var results = await GetFundamentalStockAsync((new[] { symbol }).ToList());
             return results.FirstOrDefault();
         }
-        
+
         public async Task<IList<FundamentalStock>> GetFundamentalStockAsync(IList<string> symbols)
         {
             if (_fundamentalDataAsyncClient == null)
@@ -137,10 +134,10 @@ namespace EODHistoricalData.NET
             {
                 list.Add(await _fundamentalDataAsyncClient.GetFundamentalStockAsync(symbol));
             }
-            
+
             return list;
         }
-        
+
         /// <summary>
         /// To get an access to bulk fundamentals API,
         /// you should subscribe to ‘Extended Fundamentals’ package,
@@ -165,7 +162,7 @@ namespace EODHistoricalData.NET
             var results = await _fundamentalDataAsyncClient.GetBulkFundamentalsStocksAsync(exchange, offset, limit);
             return results?.Values;
         }
-        
+
         public Task<FundamentalFund> GetFundamentalFundAsync(string symbol)
         {
             if (_fundamentalDataAsyncClient == null)
@@ -189,7 +186,7 @@ namespace EODHistoricalData.NET
 
             return _fundamentalDataAsyncClient.GetIndexCompositionAsync(symbol);
         }
-        
+
         public Task<List<Instrument>> GetExchangeInstrumentsAsync(string exchangeCode)
         {
             if (_fundamentalDataAsyncClient == null)
@@ -197,7 +194,7 @@ namespace EODHistoricalData.NET
 
             return _fundamentalDataAsyncClient.GetExchangeInstrumentsAsync(exchangeCode);
         }
-        
+
         public Task<List<Exchange>> GetExchangeListAsync()
         {
             if (_exchangesDataAsyncClient == null)
@@ -212,7 +209,34 @@ namespace EODHistoricalData.NET
 
             return _searchAsyncClient.SearchAsync(isin);
         }
-        
+
+        public async Task<IEnumerable<BulkDividend>> GetBulkEndOfLastDayDividendsAsync(DateTime? referenceDate = null)
+        {
+            if (_splitDividendAsyncClient == null)
+                _splitDividendAsyncClient = new SplitDividendAsyncClient(_apiToken, _useProxy);
+
+            var results = await _splitDividendAsyncClient.GetLastDayDividendsAsync(referenceDate);
+            return results;
+        }
+
+        public async Task<IEnumerable<BulkShareSplit>> GetBulkEndOfLastDaySplitsAsync(DateTime? referenceDate = null)
+        {
+            if (_splitDividendAsyncClient == null)
+                _splitDividendAsyncClient = new SplitDividendAsyncClient(_apiToken, _useProxy);
+
+            var results = await _splitDividendAsyncClient.GetLastDaySplitsAsync(referenceDate);
+            return results;
+        }
+
+        public async Task<IEnumerable<BulkHistoricalPrice>> GetBulkEndOfLastDayStocksAsync(DateTime? referenceDate = null, string[] symbols = null)
+        {
+            if (_stockPriceDataAsyncClient == null)
+                _stockPriceDataAsyncClient = new StockPriceDataAsyncClient(_apiToken, _useProxy);
+
+            var results = await _stockPriceDataAsyncClient.GetLastDayPricesAsync(referenceDate, symbols);
+            return results;
+        }
+
         public void Dispose()
         {
             _stockPriceDataAsyncClient?.Dispose();

--- a/EODHistoricalData.NET/EODHistoricalDataClient.cs
+++ b/EODHistoricalData.NET/EODHistoricalDataClient.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace EODHistoricalData.NET
 {
     [Obsolete("This Class is Deprecated, please use EODHistoricalDataAsyncClient instead.", false)]
     public class EODHistoricalDataClient : AuthentifiedClient, IDisposable
     {
-        public const string DateFormat = "yyyy-MM-dd";
-
         public EODHistoricalDataClient(string api, bool useProxy = false) : base(api)
         {
             _useProxy = useProxy;

--- a/EODHistoricalData.NET/HttpApiAsyncClient.cs
+++ b/EODHistoricalData.NET/HttpApiAsyncClient.cs
@@ -24,36 +24,36 @@ namespace EODHistoricalData.NET
             }
             else
                 _httpClient = new HttpClient();
+
+            _httpClient.Timeout = TimeSpan.FromSeconds(250);
         }
 
         protected async Task<T> ExecuteQueryAsync<T>(string uri, Func<HttpResponseMessage, Task<T>> handler)
         {
-            Polly.Retry.AsyncRetryPolicy<HttpResponseMessage> httpRetryPolicy = Policy
-                .HandleResult<HttpResponseMessage>(r => r.StatusCode == (HttpStatusCode)429)
-                .WaitAndRetryAsync(new[]
-                {
-                    TimeSpan.FromSeconds(30),
-                    TimeSpan.FromSeconds(60),
-                    TimeSpan.FromSeconds(90)
-                },
-                onRetry: (outcome, timespan, retryAttempt, context) =>
-                {
-                    //included for debug to see what the response is
-                });
+            var retryPolicy = Policy
+                .HandleResult<HttpResponseMessage>(response => Utils.CheckStatus(response.StatusCode))
+                .Or<HttpRequestException>()
+                .WaitAndRetryAsync(retryCount: Utils.MAX_HTTP_RETRIES,
+                                   sleepDurationProvider: Utils.CalculateRetryInterval,
+                                   onRetry: (exception, sleepDuration, attemptNumber, context) =>
+                                   {
+                                       //Console.WriteLine($"Too many requests. Retrying in {sleepDuration}. {attemptNumber} / {Utils.MAX_HTTP_RETRIES}");
+                                   });
 
-            var response = await httpRetryPolicy.ExecuteAndCaptureAsync(() => _httpClient.GetAsync(uri));
+            var response = await retryPolicy.ExecuteAndCaptureAsync(() => _httpClient.GetAsync(uri));
 
             if (response.Outcome == OutcomeType.Successful)
             {
                 if (response.Result.IsSuccessStatusCode)
                     return await handler(response.Result);
 
-                throw new HttpRequestException($"There was an error while executing the HTTP query. Reason: {response.Result.ReasonPhrase}");
+                throw new HttpRequestException($"There was an error while executing the HTTP query.",
+                    new BusinessObjects.EODException(response.Result.StatusCode, response.Result.ReasonPhrase, response.Result.ToString()));
             }
             else
             {
                 var reason = response.FinalHandledResult != null ? response.FinalHandledResult.ReasonPhrase : response.FinalException.Message;
-                throw new HttpRequestException($"There was an error while executing the HTTP query. Reason: {reason}");
+                throw new HttpRequestException($"The HTTP query failed. Reason: {reason}");
             }
         }
 

--- a/EODHistoricalData.NET/HttpApiClient.cs
+++ b/EODHistoricalData.NET/HttpApiClient.cs
@@ -23,38 +23,38 @@ namespace EODHistoricalData.NET
             }
             else
                 _httpClient = new HttpClient();
+
+            _httpClient.Timeout = TimeSpan.FromSeconds(250);
         }
 
         protected delegate T QueryHandler<T>(HttpResponseMessage response);
 
         protected T ExecuteQuery<T>(string uri, QueryHandler<T> handler)
         {
-            Polly.Retry.RetryPolicy<HttpResponseMessage> httpRetryPolicy = Policy
-                .HandleResult<HttpResponseMessage>(r => r.StatusCode == (HttpStatusCode)429)
-                .WaitAndRetry(new[]
-                {
-                    TimeSpan.FromSeconds(30),
-                    TimeSpan.FromSeconds(60),
-                    TimeSpan.FromSeconds(90)
-                },
-                onRetry: (outcome, timespan, retryAttempt, context) =>
-                {
-                    //included for debug to see what the response is
-                });
+            var retryPolicy = Policy
+                .HandleResult<HttpResponseMessage>(response => Utils.CheckStatus(response.StatusCode))
+                .Or<HttpRequestException>()
+                .WaitAndRetryAsync(retryCount: Utils.MAX_HTTP_RETRIES,
+                                   sleepDurationProvider: Utils.CalculateRetryInterval,
+                                   onRetry: (exception, sleepDuration, attemptNumber, context) =>
+                                   {
+                                       //Console.WriteLine($"Too many requests. Retrying in {sleepDuration}. {attemptNumber} / {Utils.MAX_HTTP_RETRIES}");
+                                   });
 
-            var response = httpRetryPolicy.ExecuteAndCapture(() => _httpClient.GetAsync(uri).Result);
+            var response = retryPolicy.ExecuteAndCaptureAsync(() => _httpClient.GetAsync(uri)).Result;
 
             if (response.Outcome == OutcomeType.Successful)
             {
                 if (response.Result.IsSuccessStatusCode)
                     return handler(response.Result);
 
-                throw new HttpRequestException($"There was an error while executing the HTTP query. Reason: {response.Result.ReasonPhrase}");
+                throw new HttpRequestException($"There was an error while executing the HTTP query.",
+                    new BusinessObjects.EODException(response.Result.StatusCode, response.Result.ReasonPhrase, response.Result.ToString()));
             }
             else
             {
                 var reason = response.FinalHandledResult != null ? response.FinalHandledResult.ReasonPhrase : response.FinalException.Message;
-                throw new HttpRequestException($"There was an error while executing the HTTP query. Reason: {reason}");
+                throw new HttpRequestException($"The HTTP query failed. Reason: {reason}");
             }
         }
 

--- a/EODHistoricalData.NET/SplitDividendAsyncClient.cs
+++ b/EODHistoricalData.NET/SplitDividendAsyncClient.cs
@@ -9,6 +9,8 @@ namespace EODHistoricalData.NET
     {
         private const string DividendDataUrl = "https://eodhistoricaldata.com/api/div/{0}?api_token={1}{2}&fmt=json";
         private const string SplitDataUrl = "https://eodhistoricaldata.com/api/splits/{0}?api_token={1}{2}&fmt=json";
+        private const string BulkLastDayDividendDataUrl = "https://eodhistoricaldata.com/api/eod-bulk-last-day/US?api_token={0}&type=dividends&fmt=json";
+        private const string BulkLastDaySplitDataUrl = "https://eodhistoricaldata.com/api/eod-bulk-last-day/US?api_token={0}&type=splits&fmt=json";
 
         private const string Prefix = "&";
 
@@ -25,6 +27,22 @@ namespace EODHistoricalData.NET
             return Dividend.FromJson(await response.Content.ReadAsStringAsync());
         }
 
+        internal Task<List<BulkDividend>> GetLastDayDividendsAsync(DateTime? endOfDayDate)
+        {
+            var dateParameter = Utils.GetDateParameterAsString(endOfDayDate, Prefix);
+
+            var optionalParameters = "";
+            if (string.IsNullOrWhiteSpace(dateParameter))
+                optionalParameters = dateParameter;
+
+            return ExecuteQueryAsync(string.Format(BulkLastDayDividendDataUrl, _apiToken) + optionalParameters, GetBulkDividendsFromResponseAsync);
+        }
+
+        private async Task<List<BulkDividend>> GetBulkDividendsFromResponseAsync(HttpResponseMessage response)
+        {
+            return BulkDividend.FromJson(await response.Content.ReadAsStringAsync());
+        }
+
         internal Task<List<ShareSplit>> GetShareSplitsAsync(string symbol, DateTime? startDate, DateTime? endDate)
         {
             var dateParameters = Utils.GetDateParametersAsString(startDate, endDate, Prefix);
@@ -34,6 +52,22 @@ namespace EODHistoricalData.NET
         private async Task<List<ShareSplit>> GetSplitsFromResponseAsync(HttpResponseMessage response)
         {
             return ShareSplit.FromJson(await response.Content.ReadAsStringAsync());
+        }
+
+        internal Task<List<BulkShareSplit>> GetLastDaySplitsAsync(DateTime? endOfDayDate)
+        {
+            var dateParameter = Utils.GetDateParameterAsString(endOfDayDate, Prefix);
+
+            var optionalParameters = "";
+            if (string.IsNullOrWhiteSpace(dateParameter))
+                optionalParameters = dateParameter;
+
+            return ExecuteQueryAsync(string.Format(BulkLastDaySplitDataUrl, _apiToken) + optionalParameters, GetBulkSplitsFromResponseAsync);
+        }
+
+        private async Task<List<BulkShareSplit>> GetBulkSplitsFromResponseAsync(HttpResponseMessage response)
+        {
+            return BulkShareSplit.FromJson(await response.Content.ReadAsStringAsync());
         }
     }
 }

--- a/EODHistoricalData.NET/SplitDividendClient.cs
+++ b/EODHistoricalData.NET/SplitDividendClient.cs
@@ -19,7 +19,7 @@ namespace EODHistoricalData.NET
             return ExecuteQuery(string.Format(DividendDataUrl, symbol, _apiToken, dateParameters), GetDividendsFromResponse);
         }
 
-        List<Dividend> GetDividendsFromResponse(HttpResponseMessage response)
+        private List<Dividend> GetDividendsFromResponse(HttpResponseMessage response)
         {
             return Dividend.FromJson(response.Content.ReadAsStringAsync().Result);
         }

--- a/EODHistoricalData.NET/StockPriceDataClient.cs
+++ b/EODHistoricalData.NET/StockPriceDataClient.cs
@@ -19,7 +19,7 @@ namespace EODHistoricalData.NET
             return ExecuteQuery(string.Format(HistoricalDataUrl, symbol, _apiToken, dateParameters), GetHistoricalPricesFromResponse);
         }
 
-        List<HistoricalPrice> GetHistoricalPricesFromResponse(HttpResponseMessage response)
+        private List<HistoricalPrice> GetHistoricalPricesFromResponse(HttpResponseMessage response)
         {
             return HistoricalPrice.GetListFromJson(response.Content.ReadAsStringAsync().Result) ?? new List<HistoricalPrice>();
         }
@@ -40,12 +40,12 @@ namespace EODHistoricalData.NET
             return ExecuteQuery(string.Format(RealTimeDataUrl, symbol, _apiToken), GetRealTimePrice);
         }
 
-        RealTimePrice GetRealTimePrice(HttpResponseMessage response)
+        private RealTimePrice GetRealTimePrice(HttpResponseMessage response)
         {
             return RealTimePrice.FromJson(response.Content.ReadAsStringAsync().Result);
         }
 
-        List<RealTimePrice> GetRealTimePrices(HttpResponseMessage response)
+        private List<RealTimePrice> GetRealTimePrices(HttpResponseMessage response)
         {
             return SerializeRealTimePrice.GetListFromJson(response.Content.ReadAsStringAsync().Result);
         }

--- a/EODHistoricalData.NET/Utils.cs
+++ b/EODHistoricalData.NET/Utils.cs
@@ -1,13 +1,21 @@
 ﻿using System;
+using System.Net;
 using System.Text;
 
 namespace EODHistoricalData.NET
 {
     internal static class Utils
     {
+        public const string DateFormat = "yyyy-MM-dd";
+
         internal static string GetDateParametersAsString(DateTime? startDate, DateTime? endDate, string additional = null)
         {
             return GetDateParametersAsString(startDate, endDate, "from", "to", additional);
+        }
+
+        internal static string GetDateParameterAsString(DateTime? currentDate, string additional = null)
+        {
+            return GetDateParametersAsString(currentDate, null, "date", null, additional);
         }
 
         internal static string GetDateParametersAsString(DateTime? startDate, DateTime? endDate, string fromField, string toField, string additional = null)
@@ -16,15 +24,29 @@ namespace EODHistoricalData.NET
             if (additional != null)
                 sb.Append(additional);
             if (startDate.HasValue)
-                sb.Append($"{fromField}={startDate.Value.ToString(EODHistoricalDataClient.DateFormat)}");
+                sb.Append($"{fromField}={startDate.Value.ToString(Utils.DateFormat)}");
             if (endDate.HasValue)
             {
                 if (startDate.HasValue)
                     sb.Append("&");
-                sb.Append($"{toField}={endDate.Value.ToString(EODHistoricalDataClient.DateFormat)}");
+                sb.Append($"{toField}={endDate.Value.ToString(Utils.DateFormat)}");
             }
 
             return sb.ToString();
+        }
+
+        internal static int MAX_HTTP_RETRIES = 3;
+
+        internal static bool CheckStatus(HttpStatusCode status)
+        {
+            return status == (HttpStatusCode)429;
+        }
+
+        internal static TimeSpan CalculateRetryInterval(int attempt)
+        {
+            //try to make this the second half of the minute
+            //as this is likely to fail in the first part of the minute
+            return TimeSpan.FromSeconds(attempt * 30 + (30 * (attempt - 1)));
         }
     }
 }


### PR DESCRIPTION
Add batch methods for end of day prices, splits and dividends.
Update 429 retry policy.
Include detailed exception that is returned to caller when something goes wrong.