### PR TITLE
Fixed Bulk Fundamentals to limit 500 and serialisation issue

### DIFF
--- a/EODHistoricalData.NET.Tests/BulkFundamentalDataAsyncTests.cs
+++ b/EODHistoricalData.NET.Tests/BulkFundamentalDataAsyncTests.cs
@@ -22,16 +22,16 @@ namespace EODHistoricalData.NET.Tests
             var client = new EODHistoricalDataAsyncClient(Consts.ApiToken, true);
             var bulkFundamentalStocks = await client.GetBulkFundamentalStocksAsync(Consts.LargeExchange);
             Assert.IsNotNull(bulkFundamentalStocks);
-            Assert.AreEqual(1000, bulkFundamentalStocks.Count());
+            Assert.AreEqual(500, bulkFundamentalStocks.Count());
         }
         
         [TestMethod]
-        public async Task bulk_fundamental_stocks_large_returns_data_no_greater_than_1000()
+        public async Task bulk_fundamental_stocks_large_returns_data_no_greater_than_500()
         {
             var client = new EODHistoricalDataAsyncClient(Consts.ApiToken, true);
             var bulkFundamentalStocks = await client.GetBulkFundamentalStocksAsync(Consts.LargeExchange, 0, 5000);
             Assert.IsNotNull(bulkFundamentalStocks);
-            Assert.AreEqual(1000, bulkFundamentalStocks.Count());
+            Assert.AreEqual(500, bulkFundamentalStocks.Count());
         }
         
         [TestMethod]

--- a/EODHistoricalData.NET.Tests/BulkFundamentalDataTests.cs
+++ b/EODHistoricalData.NET.Tests/BulkFundamentalDataTests.cs
@@ -21,16 +21,16 @@ namespace EODHistoricalData.NET.Tests
             var client = new EODHistoricalDataClient(Consts.ApiToken, true);
             var bulkFundamentalStocks = client.GetBulkFundamentalStocks(Consts.LargeExchange);
             Assert.IsNotNull(bulkFundamentalStocks);
-            Assert.AreEqual(1000, bulkFundamentalStocks.Count());
+            Assert.AreEqual(500, bulkFundamentalStocks.Count());
         }
         
         [TestMethod]
-        public void bulk_fundamental_stocks_large_returns_data_no_greater_than_1000()
+        public void bulk_fundamental_stocks_large_returns_data_no_greater_than_500()
         {
             var client = new EODHistoricalDataClient(Consts.ApiToken, true);
             var bulkFundamentalStocks = client.GetBulkFundamentalStocks(Consts.LargeExchange, 0, 5000);
             Assert.IsNotNull(bulkFundamentalStocks);
-            Assert.AreEqual(1000, bulkFundamentalStocks.Count());
+            Assert.AreEqual(500, bulkFundamentalStocks.Count());
         }
         
         [TestMethod]

--- a/EODHistoricalData.NET.Tests/Consts.cs
+++ b/EODHistoricalData.NET.Tests/Consts.cs
@@ -17,8 +17,8 @@ namespace EODHistoricalData.NET.Tests
         internal static string LargeExchange = "LSE";
         internal static string ValidIsinNumber = "AU0000071482";
         internal static string TestCompanyName = "apple";
-        internal static DateTime StartDate = DateTime.UtcNow.AddYears(-10).AddDays(-1).Date;
-        internal static DateTime EndDate = DateTime.UtcNow.AddYears(-5).AddDays(-1).Date;
+        internal static DateTime StartDate = new DateTime(2012, 3, 14);
+        internal static DateTime EndDate = new DateTime(2017, 3, 14);
         internal static DateTime OptionsStartDate = DateTime.UtcNow.AddYears(-1).AddDays(-2).Date;
         internal static DateTime OptionsEndDate = DateTime.UtcNow.AddMonths(-1).AddDays(-1).Date;
         internal static DateTime OptionsFuture3MonthEndDate = DateTime.UtcNow.AddMonths(3).Date;

--- a/EODHistoricalData.NET.Tests/FundamentalDataAsyncTests.cs
+++ b/EODHistoricalData.NET.Tests/FundamentalDataAsyncTests.cs
@@ -47,7 +47,7 @@ namespace EODHistoricalData.NET.Tests
             using var client = new EODHistoricalDataAsyncClient(Consts.ApiToken, true);
             var instruments = await client.GetExchangeInstrumentsAsync(Consts.Exchange);
             Assert.IsNotNull(instruments);
-            Assert.IsNotNull(instruments.Count > 1000);
+            Assert.IsNotNull(instruments.Count > 500);
         }
     }
 }

--- a/EODHistoricalData.NET.Tests/FundamentalDataAsyncTests.cs
+++ b/EODHistoricalData.NET.Tests/FundamentalDataAsyncTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 
 namespace EODHistoricalData.NET.Tests
@@ -19,6 +20,8 @@ namespace EODHistoricalData.NET.Tests
         {
             using var client = new EODHistoricalDataAsyncClient(Consts.ApiToken, true);
             var fundamental = await client.GetFundamentalETFAsync(Consts.TestETF);
+            
+            Assert.IsNotNull(fundamental.EtfData.Top10_Holdings.First().Value.Assets);
             Assert.IsNotNull(fundamental);
         }
 

--- a/EODHistoricalData.NET.Tests/FundamentalDataTests.cs
+++ b/EODHistoricalData.NET.Tests/FundamentalDataTests.cs
@@ -43,7 +43,7 @@ namespace EODHistoricalData.NET.Tests
             using var client = new EODHistoricalDataClient(Consts.ApiToken, true);
             var instruments = client.GetExchangeInstruments(Consts.Exchange);
             Assert.IsNotNull(instruments);
-            Assert.IsNotNull(instruments.Count > 1000);
+            Assert.IsNotNull(instruments.Count > 500);
         }
     }
 }

--- a/EODHistoricalData.NET/BusinessObjects/FundamentalETF.cs
+++ b/EODHistoricalData.NET/BusinessObjects/FundamentalETF.cs
@@ -120,13 +120,13 @@ namespace EODHistoricalData.NET
 
     public partial class Allocation
     {
-        [JsonProperty("Long_ % ")]
+        [JsonProperty("Long_%")]
         public decimal? Long { get; set; }
 
-        [JsonProperty("Short_ % ")]
+        [JsonProperty("Short_%")]
         public decimal? Short { get; set; }
 
-        [JsonProperty("Net_Assets_ % ")]
+        [JsonProperty("Net_Assets_%")]
         public decimal? NetAssets { get; set; }
     }
 
@@ -150,7 +150,7 @@ namespace EODHistoricalData.NET
         [JsonProperty("Region")]
         public string Region { get; set; }
 
-        [JsonProperty("Assets_ % ")]
+        [JsonProperty("Assets_%")]
         public decimal? Assets { get; set; }
     }
 
@@ -210,7 +210,7 @@ namespace EODHistoricalData.NET
 
     public partial class AllocWeight
     {
-        [JsonProperty("Equity_ % ")]
+        [JsonProperty("Equity_%")]
         public decimal? Equity { get; set; }
 
         [JsonProperty("Relative_to_Category")]

--- a/EODHistoricalData.NET/EODHistoricalDataAsyncClient.cs
+++ b/EODHistoricalData.NET/EODHistoricalDataAsyncClient.cs
@@ -178,13 +178,13 @@ namespace EODHistoricalData.NET
         /// NASDAQ, NYSE (or ‘NYSE MKT’), BATS, and AMEX.
         /// All non-US exchanges supported as is.
         ///
-        /// By default offset = 0 and limit = 1000
+        /// By default offset = 0 and limit = 500
         /// </summary>
         /// <param name="exchange">The exchange code</param>
         /// <param name="offset">The number of records to skip</param>
-        /// <param name="limit">If the ‘limit’ parameter is bigger than 1000, it will be reset to 1000.</param>
+        /// <param name="limit">If the ‘limit’ parameter is bigger than 500, it will be reset to 500.</param>
         /// <returns></returns>
-        public async Task<IEnumerable<FundamentalStock>> GetBulkFundamentalStocksAsync(string exchange, int offset = 0, int limit = 1000)
+        public async Task<IEnumerable<FundamentalStock>> GetBulkFundamentalStocksAsync(string exchange, int offset = 0, int limit = 500)
         {
             if (_fundamentalDataAsyncClient == null)
                 _fundamentalDataAsyncClient = new FundamentalDataAsyncClient(_apiToken, _useProxy);

--- a/EODHistoricalData.NET/EODHistoricalDataClient.cs
+++ b/EODHistoricalData.NET/EODHistoricalDataClient.cs
@@ -155,14 +155,14 @@ namespace EODHistoricalData.NET
         /// NASDAQ, NYSE (or ‘NYSE MKT’), BATS, and AMEX.
         /// All non-US exchanges supported as is.
         ///
-        /// By default offset = 0 and limit = 1000
+        /// By default offset = 0 and limit = 500
         /// </summary>
         /// <param name="exchange">The exchange code</param>
         /// <param name="offset">The number of records to skip</param>
-        /// <param name="limit">If the ‘limit’ parameter is bigger than 1000, it will be reset to 1000.</param>
+        /// <param name="limit">If the ‘limit’ parameter is bigger than 500, it will be reset to 500.</param>
         /// <returns></returns>
         [Obsolete("This Method is Deprecated, please use GetBulkFundamentalStocksAsync instead.", false)]
-        public IEnumerable<FundamentalStock> GetBulkFundamentalStocks(string exchange, int offset = 0, int limit = 1000)
+        public IEnumerable<FundamentalStock> GetBulkFundamentalStocks(string exchange, int offset = 0, int limit = 500)
         {
             if (_fundamentalDataClient == null)
                 _fundamentalDataClient = new FundamentalDataClient(_apiToken, _useProxy);

--- a/EODHistoricalData.NET/FundamentalDataAsyncClient.cs
+++ b/EODHistoricalData.NET/FundamentalDataAsyncClient.cs
@@ -31,8 +31,7 @@ namespace EODHistoricalData.NET
                 limit = 500;
             }
 
-            var url = string.Format(BulkFundamentalUrl, exchange, _apiToken, offset, limit);
-            return ExecuteQueryAsync(url, GetBulkFundamentalStocksFromResponseAsync);
+            return ExecuteQueryAsync(string.Format(BulkFundamentalUrl, exchange, _apiToken, offset, limit), GetBulkFundamentalStocksFromResponseAsync);
         }
 
         private async Task<BulkFundamentalStocks> GetBulkFundamentalStocksFromResponseAsync(HttpResponseMessage response)

--- a/EODHistoricalData.NET/FundamentalDataAsyncClient.cs
+++ b/EODHistoricalData.NET/FundamentalDataAsyncClient.cs
@@ -25,12 +25,14 @@ namespace EODHistoricalData.NET
         internal Task<BulkFundamentalStocks> GetBulkFundamentalsStocksAsync(string exchange, int offset, int limit)
         {
             // https://eodhistoricaldata.com/financial-apis/stock-etfs-fundamental-data-feeds/#Bulk_Fundamentals_API
-            // If the ‘limit’ parameter is bigger than 1000, it will be reset to 1000.
-            if (limit > 1000)
+            // If the ‘limit’ parameter is bigger than 500, it will be reset to 500.
+            if (limit > 500)
             {
-                limit = 1000;
+                limit = 500;
             }
-            return ExecuteQueryAsync(string.Format(BulkFundamentalUrl, exchange, _apiToken, offset, limit), GetBulkFundamentalStocksFromResponseAsync);
+
+            var url = string.Format(BulkFundamentalUrl, exchange, _apiToken, offset, limit);
+            return ExecuteQueryAsync(url, GetBulkFundamentalStocksFromResponseAsync);
         }
 
         private async Task<BulkFundamentalStocks> GetBulkFundamentalStocksFromResponseAsync(HttpResponseMessage response)

--- a/EODHistoricalData.NET/FundamentalDataClient.cs
+++ b/EODHistoricalData.NET/FundamentalDataClient.cs
@@ -6,7 +6,7 @@ namespace EODHistoricalData.NET
 {
     internal class FundamentalDataClient : HttpApiClient
     {
-        private const string FundamentalUrl = @"https://eodhistoricaldata.com/api/fundamentals/{0}?api_token={1}";
+        private const string FundamentalUrl = @"https://eodhistoricaldata.com/api/fundamentals/{0}?api_token={1}&fmt=json";
         private const string ExchangeUrl = @"https://eodhistoricaldata.com/api/exchanges/{0}?api_token={1}&fmt=json";
         private const string BulkFundamentalUrl = @"https://eodhistoricaldata.com/api/bulk-fundamentals/{0}?api_token={1}&offset={2}&limit={3}&fmt=json";
         

--- a/EODHistoricalData.NET/FundamentalDataClient.cs
+++ b/EODHistoricalData.NET/FundamentalDataClient.cs
@@ -25,10 +25,10 @@ namespace EODHistoricalData.NET
         internal BulkFundamentalStocks GetBulkFundamentalsStocks(string exchange, int offset, int limit)
         {
             // https://eodhistoricaldata.com/financial-apis/stock-etfs-fundamental-data-feeds/#Bulk_Fundamentals_API
-            // If the ‘limit’ parameter is bigger than 1000, it will be reset to 1000.
-            if (limit > 1000)
+            // If the ‘limit’ parameter is bigger than 500, it will be reset to 500.
+            if (limit > 500)
             {
-                limit = 1000;
+                limit = 500;
             }
             return ExecuteQuery(string.Format(BulkFundamentalUrl, exchange, _apiToken, offset, limit), GetBulkFundamentalStocksFromResponse);
         }


### PR DESCRIPTION
I've updated the Bulk Fundamentals to limit to 500 as changed in the API

Also updated a couple of tags that weren't serializing

Finally fixed some dates that were using DateTime.UTC to be static due to timezones and failures if it's Monday