### PR TITLE
Upgrade target framework and bulk data limit

### DIFF
--- a/EODHistoricalData.NET.Tests/BulkFundamentalDataAsyncTests.cs
+++ b/EODHistoricalData.NET.Tests/BulkFundamentalDataAsyncTests.cs
@@ -26,12 +26,12 @@ namespace EODHistoricalData.NET.Tests
         }
         
         [TestMethod]
-        public async Task bulk_fundamental_stocks_large_returns_data_no_greater_than_1000()
+        public async Task bulk_fundamental_stocks_large_returns_data_no_greater_than_500()
         {
             var client = new EODHistoricalDataAsyncClient(Consts.ApiToken, true);
             var bulkFundamentalStocks = await client.GetBulkFundamentalStocksAsync(Consts.LargeExchange, 0, 5000);
             Assert.IsNotNull(bulkFundamentalStocks);
-            Assert.AreEqual(1000, bulkFundamentalStocks.Count());
+            Assert.AreEqual(500, bulkFundamentalStocks.Count());
         }
         
         [TestMethod]

--- a/EODHistoricalData.NET.Tests/BulkFundamentalDataTests.cs
+++ b/EODHistoricalData.NET.Tests/BulkFundamentalDataTests.cs
@@ -25,12 +25,12 @@ namespace EODHistoricalData.NET.Tests
         }
         
         [TestMethod]
-        public void bulk_fundamental_stocks_large_returns_data_no_greater_than_1000()
+        public void bulk_fundamental_stocks_large_returns_data_no_greater_than_500()
         {
             var client = new EODHistoricalDataClient(Consts.ApiToken, true);
             var bulkFundamentalStocks = client.GetBulkFundamentalStocks(Consts.LargeExchange, 0, 5000);
             Assert.IsNotNull(bulkFundamentalStocks);
-            Assert.AreEqual(1000, bulkFundamentalStocks.Count());
+            Assert.AreEqual(500, bulkFundamentalStocks.Count());
         }
         
         [TestMethod]

--- a/EODHistoricalData.NET.Tests/EODHistoricalData.NET.Tests.csproj
+++ b/EODHistoricalData.NET.Tests/EODHistoricalData.NET.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/EODHistoricalData.NET/EODHistoricalData.NET.csproj
+++ b/EODHistoricalData.NET/EODHistoricalData.NET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
 

--- a/EODHistoricalData.NET/EODHistoricalDataAsyncClient.cs
+++ b/EODHistoricalData.NET/EODHistoricalDataAsyncClient.cs
@@ -184,7 +184,7 @@ namespace EODHistoricalData.NET
         /// <param name="offset">The number of records to skip</param>
         /// <param name="limit">If the ‘limit’ parameter is bigger than 1000, it will be reset to 1000.</param>
         /// <returns></returns>
-        public async Task<IEnumerable<FundamentalStock>> GetBulkFundamentalStocksAsync(string exchange, int offset = 0, int limit = 1000)
+        public async Task<IEnumerable<FundamentalStock>> GetBulkFundamentalStocksAsync(string exchange, int offset = 0, int limit = 500)
         {
             if (_fundamentalDataAsyncClient == null)
                 _fundamentalDataAsyncClient = new FundamentalDataAsyncClient(_apiToken, _useProxy);

--- a/EODHistoricalData.NET/EODHistoricalDataClient.cs
+++ b/EODHistoricalData.NET/EODHistoricalDataClient.cs
@@ -162,7 +162,7 @@ namespace EODHistoricalData.NET
         /// <param name="limit">If the ‘limit’ parameter is bigger than 1000, it will be reset to 1000.</param>
         /// <returns></returns>
         [Obsolete("This Method is Deprecated, please use GetBulkFundamentalStocksAsync instead.", false)]
-        public IEnumerable<FundamentalStock> GetBulkFundamentalStocks(string exchange, int offset = 0, int limit = 1000)
+        public IEnumerable<FundamentalStock> GetBulkFundamentalStocks(string exchange, int offset = 0, int limit = 500)
         {
             if (_fundamentalDataClient == null)
                 _fundamentalDataClient = new FundamentalDataClient(_apiToken, _useProxy);

--- a/EODHistoricalData.NET/FundamentalDataAsyncClient.cs
+++ b/EODHistoricalData.NET/FundamentalDataAsyncClient.cs
@@ -25,11 +25,11 @@ namespace EODHistoricalData.NET
         internal Task<BulkFundamentalStocks> GetBulkFundamentalsStocksAsync(string exchange, int offset, int limit)
         {
             // https://eodhistoricaldata.com/financial-apis/stock-etfs-fundamental-data-feeds/#Bulk_Fundamentals_API
-            // If the ‘limit’ parameter is bigger than 1000, it will be reset to 1000.
-            if (limit > 1000)
-            {
-                limit = 1000;
-            }
+            // If the ‘limit’ parameter is bigger than 500, it will be reset to 500.
+            limit = limit > 500
+                ? 500
+                : limit;
+            
             return ExecuteQueryAsync(string.Format(BulkFundamentalUrl, exchange, _apiToken, offset, limit), GetBulkFundamentalStocksFromResponseAsync);
         }
 

--- a/EODHistoricalData.NET/FundamentalDataClient.cs
+++ b/EODHistoricalData.NET/FundamentalDataClient.cs
@@ -25,11 +25,11 @@ namespace EODHistoricalData.NET
         internal BulkFundamentalStocks GetBulkFundamentalsStocks(string exchange, int offset, int limit)
         {
             // https://eodhistoricaldata.com/financial-apis/stock-etfs-fundamental-data-feeds/#Bulk_Fundamentals_API
-            // If the ‘limit’ parameter is bigger than 1000, it will be reset to 1000.
-            if (limit > 1000)
-            {
-                limit = 1000;
-            }
+            // If the ‘limit’ parameter is bigger than 500, it will be reset to 500.
+            limit = limit > 500
+                ? 500
+                : limit;
+            
             return ExecuteQuery(string.Format(BulkFundamentalUrl, exchange, _apiToken, offset, limit), GetBulkFundamentalStocksFromResponse);
         }
 


### PR DESCRIPTION
- Updated target framework to .net7
- Set new limit (500) for bulk requests (since my test api key is not allowed to consume bulk data, the unit test is showing forbidden instead of an "Unprocessable entity" error with a limit of 1000)